### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/hash-lambda/main.rkt
+++ b/hash-lambda/main.rkt
@@ -25,7 +25,7 @@
          racket/contract
          racket/list
          racket/math
-         unstable/hash
+         racket/hash
          kw-utils/keyword-lambda
          kw-utils/keyword-apply-sort
          kw-utils/keyword-app

--- a/info.rkt
+++ b/info.rkt
@@ -3,7 +3,6 @@
 (define collection 'multi)
 
 (define deps '("base"
-               "unstable-list-lib"
                "kw-utils"
                "mutable-match-lambda"
                "rackunit-lib"


### PR DESCRIPTION
Most of the functionality of that package will be moved into the core libraries by Racket PR #972, and `unstable-list-lib` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-list-lib` package, as it will not be part of the main distribution in future versions.
