### PR TITLE
Use `make-variable-like-transformer` from `syntax/transformer`

### DIFF
--- a/hash-lambda/main.rkt
+++ b/hash-lambda/main.rkt
@@ -32,7 +32,7 @@
          kw-utils/kw-hash
          (except-in kw-utils/arity+keywords arity-map)
          "prop-object-name.rkt"
-         (for-syntax racket/base syntax/parse racket/list syntax/name unstable/syntax
+         (for-syntax racket/base syntax/parse racket/list syntax/name syntax/transformer
                      (for-syntax racket/base
                                  )))
 (module+ test

--- a/info.rkt
+++ b/info.rkt
@@ -2,7 +2,7 @@
 
 (define collection 'multi)
 
-(define deps '("base"
+(define deps '(("base" #:version "6.2.900.6")
                "unstable-list-lib"
                "kw-utils"
                "mutable-match-lambda"


### PR DESCRIPTION
That binding is provided by `syntax/transformer` as of 6.2.900.6, and `unstable/syntax` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-lib` package, as it will not be part of the main distribution in future versions.
